### PR TITLE
Replace static SystemClock with mockable interface

### DIFF
--- a/src/DateTimeExtensions.cs
+++ b/src/DateTimeExtensions.cs
@@ -2,8 +2,17 @@
 
 namespace Archon
 {
+	/// <summary>
+	/// Provides utility extension methods to DateTime
+	/// </summary>
 	public static class DateTimeExtensions
 	{
+		/// <summary>
+		/// Assume the DateTime is UTC. If the kind is unspecified, it will be coerced to UTC. If the kind is Local, an ArgumentException will be thrown.
+		/// </summary>
+		/// <param name="date">The datetime to check</param>
+		/// <param name="name">The name of the parameter being checked (to be used when throwing an exception)</param>
+		/// <returns>The specified DateTime but with a kind of UTC</returns>
 		public static DateTime AssumeUtc(this DateTime date, string name)
 		{
 			if (date.Kind == DateTimeKind.Unspecified)
@@ -15,6 +24,12 @@ namespace Archon
 			return date;
 		}
 
+		/// <summary>
+		/// Assume the DateTime is UTC. If the kind is unspecified, it will be coerced to UTC. If the kind is Local, an ArgumentException will be thrown.
+		/// </summary>
+		/// <param name="date">The datetime to check</param>
+		/// <param name="name">The name of the parameter being checked (to be used when throwing an exception)</param>
+		/// <returns>The specified DateTime but with a kind of UTC</returns>
 		public static DateTime? AssumeUtc(this DateTime? date, string name)
 		{
 			if (!date.HasValue)

--- a/src/FrozenSystemClock.cs
+++ b/src/FrozenSystemClock.cs
@@ -48,10 +48,7 @@ namespace Archon
 		/// <param name="frozenTimeUtc">The UTC time to freeze</param>
 		public void Reset(DateTime frozenTimeUtc)
 		{
-			if (frozenTimeUtc.Kind != DateTimeKind.Utc)
-				throw new ArgumentException("Value must be a UTC DateTime.", nameof(frozenTimeUtc));
-
-			frozen = frozenTimeUtc;
+			frozen = frozenTimeUtc.AssumeUtc(nameof(frozenTimeUtc));
 		}
 
 		/// <summary>

--- a/src/FrozenSystemClock.cs
+++ b/src/FrozenSystemClock.cs
@@ -1,0 +1,142 @@
+﻿using System;
+
+namespace Archon
+{
+	/// <summary>
+	/// Frozen implementation of SystemClock
+	/// </summary>
+	public class FrozenSystemClock : SystemClock
+	{
+		DateTime frozen;
+
+		/// <summary>
+		/// Gets the current frozen time in UTC
+		/// </summary>
+		public DateTime UtcNow => frozen;
+
+		/// <summary>
+		/// Gets the current frozen time in local time
+		/// </summary>
+		public DateTime Now => frozen.ToLocalTime();
+
+		/// <summary>
+		/// Creates a new instance using the current UTC time as the frozen time
+		/// </summary>
+		public FrozenSystemClock()
+			: this(DateTime.UtcNow) { }
+
+		/// <summary>
+		/// Creates a new instance using the specified UTC frozen time
+		/// </summary>
+		/// <param name="frozenTimeUtc">The UTC time to freeze</param>
+		public FrozenSystemClock(DateTime frozenTimeUtc)
+		{
+			Reset(frozenTimeUtc);
+		}
+
+		/// <summary>
+		/// Reset the current frozen time to DateTime.UtcNow
+		/// </summary>
+		public void Reset()
+		{
+			Reset(DateTime.UtcNow);
+		}
+
+		/// <summary>
+		/// Reset the current frozen time to the specified UTC time
+		/// </summary>
+		/// <param name="frozenTimeUtc">The UTC time to freeze</param>
+		public void Reset(DateTime frozenTimeUtc)
+		{
+			if (frozenTimeUtc.Kind != DateTimeKind.Utc)
+				throw new ArgumentException("Value must be a UTC DateTime.", nameof(frozenTimeUtc));
+
+			frozen = frozenTimeUtc;
+		}
+
+		/// <summary>
+		/// Add years to the current frozen time
+		/// </summary>
+		/// <param name="value">The number of years</param>
+		public void AddYears(int value)
+		{
+			frozen = frozen.AddYears(value);
+		}
+
+		/// <summary>
+		/// Add months to the current frozen time
+		/// </summary>
+		/// <param name="value">The number of months</param>
+		public void AddMonths(int value)
+		{
+			frozen = frozen.AddMonths(value);
+		}
+
+		/// <summary>
+		/// Add days to the current frozen time
+		/// </summary>
+		/// <param name="value">The number of days</param>
+		public void AddDays(double value)
+		{
+			frozen = frozen.AddDays(value);
+		}
+
+		/// <summary>
+		/// Add hours to the current frozen time
+		/// </summary>
+		/// <param name="value">The number of hours</param>
+		public void AddHours(double value)
+		{
+			frozen = frozen.AddHours(value);
+		}
+
+		/// <summary>
+		/// Add minutes to the current frozen time
+		/// </summary>
+		/// <param name="value">The number of minutes</param>
+		public void AddMinutes(double value)
+		{
+			frozen = frozen.AddMinutes(value);
+		}
+
+		/// <summary>
+		/// Add seconds to the current frozen time
+		/// </summary>
+		/// <param name="value">The number of seconds</param>
+		public void AddSeconds(double value)
+		{
+			frozen = frozen.AddSeconds(value);
+		}
+
+		/// <summary>
+		/// Returns a value indicating whether this instance is equal to a specified object.
+		/// </summary>
+		/// <param name="obj">The object to compare to this instance.</param>
+		/// <returns>true if value is an instance of System.DateTime or FrozenSystemClock and equals the value of this instance's frozen time; otherwise, false.</returns>
+		public override bool Equals(object obj)
+		{
+			if (obj is FrozenSystemClock fro)
+				return frozen.Equals(fro.frozen);
+
+			return frozen.Equals(obj);
+		}
+
+		/// <summary>
+		/// Gets the hash code of the current frozen time
+		/// </summary>
+		/// <returns></returns>
+		public override int GetHashCode()
+		{
+			return frozen.GetHashCode();
+		}
+
+		/// <summary>
+		/// Returns the current frozen time as a string
+		/// </summary>
+		/// <returns>The current frozen time as a string</returns>
+		public override string ToString()
+		{
+			return frozen.ToString();
+		}
+	}
+}

--- a/src/RealSystemClock.cs
+++ b/src/RealSystemClock.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Archon
+{
+	/// <summary>
+	/// Implementation of SystemClock which just uses the current DateTime.UtcNow
+	/// </summary>
+	public class RealSystemClock : SystemClock
+	{
+		/// <summary>
+		/// The current time in UTC
+		/// </summary>
+		public DateTime UtcNow => DateTime.UtcNow;
+
+		/// <summary>
+		/// The current time in local time
+		/// </summary>
+		public DateTime Now => DateTime.Now;
+	}
+}

--- a/src/SystemClock.cs
+++ b/src/SystemClock.cs
@@ -5,30 +5,16 @@ namespace Archon
 	/// <summary>
 	/// Aids in unit testing by providing a mockable way to get the current time.
 	/// </summary>
-	public static class SystemClock
+	public interface SystemClock
 	{
-		private static DateTime? _utcNow;
+		/// <summary>
+		/// Gets the current time in UTC
+		/// </summary>
+		DateTime UtcNow { get; }
 
-		public static DateTime UtcNow
-		{
-			get
-			{
-				if (_utcNow.HasValue)
-					return _utcNow.Value;
-				return DateTime.UtcNow;
-			}
-			set { _utcNow = value; }
-		}
-
-		public static DateTime Now
-		{
-			get { return UtcNow.ToLocalTime(); }
-			set { UtcNow = value.ToUniversalTime(); }
-		}
-
-		public static void Reset()
-		{
-			_utcNow = null;
-		}
+		/// <summary>
+		/// Gets the current local time
+		/// </summary>
+		DateTime Now { get; }
 	}
 }

--- a/src/time.csproj
+++ b/src/time.csproj
@@ -20,6 +20,11 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
+    <DocumentationFile>bin\Release\netstandard1.0\Archon.Time.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DocumentationFile>bin\Debug\netstandard1.0\Archon.Time.xml</DocumentationFile>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
`SystemClock` is now an interface that can be injected into components. There are now two implementations:
* `RealSystemClock`: Just passes through to `DateTime.UtcNow`
* `FrozenSystemClock`: Freezes the clock at the specified time with some convenience methods for moving time forward or backwards

This will allow consumers to mock the current time while testing without having to give up [test parallelization](https://xunit.github.io/docs/running-tests-in-parallel.html).

Need this for [CS-15572](https://jira.archoninfosys.com:8181/browse/CS-15572)